### PR TITLE
Add ClimateCool core climate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.3.0
+- Add ClimateCool core climate support with cooling-only controls and state reporting.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ print(state.mode, state.remaining_minutes)
 
 Heating modes are not available on ClimateCool models.
 
+## Integration testing
+
+The repository includes a small script to exercise the ClimateCool APIs
+against a real account. Credentials are read from the `SLEEPIQ_USERNAME`
+and `SLEEPIQ_PASSWORD` environment variables or will be prompted for at
+runtime.
+
+```bash
+python scripts/climatecool_integration.py
+```
+
+Optionally set the core climate for the first bed by providing side,
+mode, and minutes:
+
+```bash
+python scripts/climatecool_integration.py --set left cooling_pull_med 240
+```
+
 ## Future Development
 
 Without documentation for the API, development requires obvserving how other interfaces interact with it.  Given the hardware dependencies are fairly high, any future development requires someone with the appropriate bed to be able to obvserve and test against.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AsyncSleepIQ
 
-AsyncSleepIQ is an library for accessing the SleepIQ API from Python. [SleepIQ](http://www.sleepnumber.com/sn/en/sleepiq-sleep-tracker) is an addon for [SleepNumber beds](http://www.sleepnumber.com/).
+AsyncSleepIQ is a library for accessing the SleepIQ API from Python. [SleepIQ](http://www.sleepnumber.com/sn/en/sleepiq-sleep-tracker) is an addon for [SleepNumber beds](http://www.sleepnumber.com/).
 
 ## Installation
 
@@ -54,6 +54,23 @@ async def main():
 
 asyncio.get_event_loop().run_until_complete(main())
 ```
+
+## Climate Features
+
+### ClimateCool
+
+ClimateCool beds support cooling-only core climate control. Modes available are
+`off`, `cooling_pull_low`, `cooling_pull_med`, and `cooling_pull_high`. The
+duration may be set between 0 and 600 minutes.
+
+```python
+bed = (await client.get_beds())[0]
+await bed.set_core_climate(side="left", mode="cooling_pull_med", minutes=240)
+state = await bed.get_core_climate("left")
+print(state.mode, state.remaining_minutes)
+```
+
+Heating modes are not available on ClimateCool models.
 
 ## Future Development
 

--- a/asyncsleepiq/__init__.py
+++ b/asyncsleepiq/__init__.py
@@ -3,7 +3,7 @@ from .asyncsleepiq import AsyncSleepIQ
 from .actuator import SleepIQActuator
 from .bed import SleepIQBed
 from .consts import *
-from .core_climate import SleepIQCoreClimate
+from .core_climate import CoreClimateState, SleepIQCoreClimate
 from .exceptions import (
     SleepIQAPIException,
     SleepIQLoginException,
@@ -15,4 +15,4 @@ from .light import SleepIQLight
 from .preset import SleepIQPreset
 from .sleeper import SleepIQSleeper
 
-__version__ = "{{VERSION_PLACEHOLDER}}"
+__version__ = "0.3.0"

--- a/asyncsleepiq/bed.py
+++ b/asyncsleepiq/bed.py
@@ -1,12 +1,28 @@
 """Bed object from SleepIQ API."""
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from .api import SleepIQAPI
 from .consts import SIDES_FULL, Side
+from .core_climate import (
+    CoreClimateState,
+    SleepIQCoreClimate,
+    CLIMATE_MODE_MAP,
+    REVERSE_CLIMATE_MODE_MAP,
+)
 from .foundation import SleepIQFoundation
 from .sleeper import SleepIQSleeper
+
+
+@dataclass
+class BedCapabilities:
+    """Available capabilities for a bed."""
+
+    core_climate_cooling_only: bool = False
+
+
 
 
 class SleepIQBed:
@@ -26,15 +42,19 @@ class SleepIQBed:
             if data.get(f"sleeper{SIDES_FULL[side]}Id")
         ]
         self.foundation = SleepIQFoundation(api, self.id)
+        self.capabilities = BedCapabilities()
 
         self.model = "Unknown"
         if "model" in data:
             self.model = data["model"]
         elif "components" in data:
             for comp in data["components"]:
-                if comp["base"] == "BASE":
+                if comp.get("base") == "BASE" and comp.get("model"):
                     self.model = comp["model"]
-                    break
+                if comp.get("productclassification") == "CLIMATECOOL" or comp.get("model") == "CLIMATECOOL":
+                    self.capabilities.core_climate_cooling_only = True
+        if self.capabilities.core_climate_cooling_only:
+            self.foundation.core_climate_cooling_only = True
 
     def __str__(self) -> str:
         """Return string representation."""
@@ -78,3 +98,40 @@ class SleepIQBed:
         params = {"mode": "on" if mode else "off"}
         await self._api.put("bed/" + self.id + "/pauseMode", params=params)
         self.paused = mode
+
+    async def get_core_climate(self, side: Literal["left", "right"]) -> CoreClimateState:
+        """Get current core climate state for a side."""
+        side_enum = Side.LEFT if side == "left" else Side.RIGHT
+        core = next((c for c in self.foundation.core_climates if c.side == side_enum), None)
+        if not core:
+            raise ValueError("Core climate not supported")
+        await core.update({})
+        mode = REVERSE_CLIMATE_MODE_MAP.get(core.temperature, "unknown")
+        minutes = core.timer if core.is_on else 0
+        return CoreClimateState(mode, minutes)
+
+    async def set_core_climate(
+        self,
+        side: Literal["left", "right"],
+        mode: Literal[
+            "off",
+            "heating_push_low",
+            "heating_push_med",
+            "heating_push_high",
+            "cooling_pull_low",
+            "cooling_pull_med",
+            "cooling_pull_high",
+        ],
+        minutes: int,
+    ) -> None:
+        """Set core climate for a side."""
+        if mode not in CLIMATE_MODE_MAP:
+            raise ValueError("Invalid core climate mode")
+        if self.capabilities.core_climate_cooling_only and mode.startswith("heating"):
+            raise ValueError("Heating not supported on this bed")
+        side_enum = Side.LEFT if side == "left" else Side.RIGHT
+        minutes = max(0, min(minutes, SleepIQCoreClimate.max_core_climate_time))
+        core = next((c for c in self.foundation.core_climates if c.side == side_enum), None)
+        if not core:
+            raise ValueError("Core climate not supported on this side")
+        await core.set_mode(CLIMATE_MODE_MAP[mode], minutes)

--- a/asyncsleepiq/consts.py
+++ b/asyncsleepiq/consts.py
@@ -117,4 +117,6 @@ BAMKEY = {
     "GetHeidiPresence": "THPG",
     "SetHeidiMode": "THMS",
     "GetHeidiMode": "THMG",
+    "SetClimateMode": "CLMS",
+    "GetClimateMode": "CLMG",
 }

--- a/asyncsleepiq/core_climate.py
+++ b/asyncsleepiq/core_climate.py
@@ -1,36 +1,68 @@
-"""Foundation for Core Climate for SleepIQ API."""
+"""Core climate component handling for SleepIQ beds."""
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from .api import SleepIQAPI
-
 from .consts import SIDES_FULL, CoreTemps, Side
 
 
+CLIMATE_MODE_MAP = {
+    "off": CoreTemps.OFF,
+    "heating_push_low": CoreTemps.HEATING_PUSH_LOW,
+    "heating_push_med": CoreTemps.HEATING_PUSH_MED,
+    "heating_push_high": CoreTemps.HEATING_PUSH_HIGH,
+    "cooling_pull_low": CoreTemps.COOLING_PULL_LOW,
+    "cooling_pull_med": CoreTemps.COOLING_PULL_MED,
+    "cooling_pull_high": CoreTemps.COOLING_PULL_HIGH,
+}
+
+
+REVERSE_CLIMATE_MODE_MAP = {v: k for k, v in CLIMATE_MODE_MAP.items()}
+
+
+@dataclass
+class CoreClimateState:
+    """State representation for core climate control."""
+
+    mode: Literal[
+        "off",
+        "heating_push_low",
+        "heating_push_med",
+        "heating_push_high",
+        "cooling_pull_low",
+        "cooling_pull_med",
+        "cooling_pull_high",
+        "unknown",
+    ]
+    remaining_minutes: int
+
+
 class SleepIQCoreClimate:
-    """
-        CoreClimate representation for SleepIQ API.
-        Controls heating and cooling.
-    """
+    """Base class for core climate components."""
 
     max_core_climate_time = 600
 
-    def __init__(self, api: SleepIQAPI, bed_id: str, side: Side, timer: int, temperature: int) -> None:
+    def __init__(self, api: SleepIQAPI, bed_id: str, side: Side, timer: int, temperature: CoreTemps) -> None:
         """Initialize CoreClimate object."""
         self._api = api
         self.bed_id = bed_id
         self.side = side
-        self.is_on = (temperature > 0)
+        self.is_on = temperature != CoreTemps.OFF
         self.timer = timer
         self.temperature = temperature
 
     def __str__(self) -> str:
         """Return string representation."""
-        return f"SleepIQCoreClimate[{self.side}]: {'On' if self.is_on else 'Off'}, {self.timer}, {CoreTemps(self.temperature).name}"
+        return (
+            f"SleepIQCoreClimate[{self.side}]: {'On' if self.is_on else 'Off'}, "
+            f"{self.timer}, {self.temperature.name}"
+        )
+
     __repr__ = __str__
 
-    async def turn_on(self, temperature: CoreTemps, time: int)  -> None:
+    async def turn_on(self, temperature: CoreTemps, time: int) -> None:
         """Turn on core climate mode through API."""
         await self.set_mode(temperature, time)
 
@@ -38,3 +70,44 @@ class SleepIQCoreClimate:
         """Turn off core climate mode through API."""
         # The API requires a valid time value even if we're turning the climate off
         await self.set_mode(CoreTemps.OFF, 1)
+
+    async def set_mode(self, temperature: CoreTemps, time: int) -> None:
+        """Set core climate mode."""
+        raise NotImplementedError
+
+    async def update(self, data: dict[str, Any]) -> None:
+        """Update core climate state."""
+        raise NotImplementedError
+
+
+class SleepIQClimateCoolCoreClimate(SleepIQCoreClimate):
+    """Core climate component for ClimateCool (cooling-only) beds."""
+
+    async def set_mode(self, temperature: CoreTemps, time: int) -> None:
+        """Set cooling mode and timer via API."""
+        if temperature in {
+            CoreTemps.HEATING_PUSH_LOW,
+            CoreTemps.HEATING_PUSH_MED,
+            CoreTemps.HEATING_PUSH_HIGH,
+        }:
+            raise ValueError("Heating modes not supported on ClimateCool beds")
+        if temperature == CoreTemps.OFF:
+            time = 0
+        if time < 0:
+            time = 0
+        if time > self.max_core_climate_time:
+            time = self.max_core_climate_time
+        args = [SIDES_FULL[self.side].lower(), REVERSE_CLIMATE_MODE_MAP[temperature], str(time)]
+        await self._api.bamkey(self.bed_id, "SetClimateMode", args)
+        await self.update({})
+
+    async def update(self, data: dict[str, Any]) -> None:
+        """Refresh cooling state from API."""
+        args = [SIDES_FULL[self.side].lower()]
+        resp = await self._api.bamkey(self.bed_id, "GetClimateMode", args)
+        parts = resp.split()
+        mode = parts[0] if parts else "off"
+        self.temperature = CLIMATE_MODE_MAP.get(mode, CoreTemps.OFF)
+        self.is_on = self.temperature != CoreTemps.OFF
+        self.timer = int(parts[1]) if self.is_on and len(parts) > 1 else 0
+

--- a/asyncsleepiq/foundation.py
+++ b/asyncsleepiq/foundation.py
@@ -10,13 +10,14 @@ from .consts import (
     FOUNDATION_TYPES,
     End,
     Mode,
+    CoreTemps,
     Side,
     Speed,
 )
 from .light import SleepIQLight
 from .foot_warmer import SleepIQFootWarmer
 from .preset import SleepIQPreset
-from .core_climate import SleepIQCoreClimate
+from .core_climate import SleepIQCoreClimate, SleepIQClimateCoolCoreClimate
 
 
 class SleepIQFoundation:
@@ -29,6 +30,7 @@ class SleepIQFoundation:
         self.lights: list[SleepIQLight] = []
         self.foot_warmers: list[SleepIQFootWarmer] = []
         self.core_climates: list[SleepIQCoreClimate] = []
+        self.core_climate_cooling_only = False
         self.features: dict[str, bool] = {
             "boardIsASingle": False,
             "hasMassageAndLight": False,
@@ -54,6 +56,7 @@ class SleepIQFoundation:
         """Initialize all foundation features."""
         await self.init_lights()
         await self.init_foot_warmers()
+        await self.init_core_climates()
 
         if not self.type:
             return
@@ -66,6 +69,7 @@ class SleepIQFoundation:
         """Update all foundation data from API."""
         await self.update_lights()
         await self.update_foot_warmers()
+        await self.update_core_climates()
 
         if not self.type:
             return
@@ -89,6 +93,23 @@ class SleepIQFoundation:
         data = await self._api.get(f"bed/{self.bed_id}/foundation/footwarming")
         for foot_warmer in self.foot_warmers:
             await foot_warmer.update(data)
+
+    async def init_core_climates(self) -> None:
+        """Initialize list of core climates available on foundation."""
+        if not self.core_climate_cooling_only:
+            return
+        for side in [Side.LEFT, Side.RIGHT]:
+            self.core_climates.append(
+                SleepIQClimateCoolCoreClimate(self._api, self.bed_id, side, 0, CoreTemps.OFF)
+            )
+        await self.update_core_climates()
+
+    async def update_core_climates(self) -> None:
+        """Update core climate states from API."""
+        if not self.core_climates:
+            return
+        for core_climate in self.core_climates:
+            await core_climate.update({})
 
     async def init_lights(self) -> None:
         """Initialize list of lights available on foundation."""

--- a/scripts/climatecool_integration.py
+++ b/scripts/climatecool_integration.py
@@ -1,0 +1,50 @@
+import argparse
+import asyncio
+import getpass
+import os
+
+from asyncsleepiq import AsyncSleepIQ
+
+
+async def main() -> None:
+    """Simple script to exercise ClimateCool core climate APIs."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--set",
+        nargs=3,
+        metavar=("SIDE", "MODE", "MINUTES"),
+        help=(
+            "Optionally set core climate for the first bed: "
+            "<side> <mode> <minutes>"
+        ),
+    )
+    args = parser.parse_args()
+
+    username = os.getenv("SLEEPIQ_USERNAME") or input("SleepIQ username: ")
+    password = os.getenv("SLEEPIQ_PASSWORD") or getpass.getpass("SleepIQ password: ")
+
+    async with AsyncSleepIQ(username, password) as api:
+        beds = await api.get_beds()
+        if not beds:
+            print("No beds found")
+            return
+        bed = beds[0]
+        print(f"Using bed {bed.bed_id} ({bed.name})")
+
+        if args.set:
+            side, mode, minutes = args.set
+            print(f"Setting {side} to {mode} for {minutes} minutes")
+            await bed.set_core_climate(side=side, mode=mode, minutes=int(minutes))
+
+        for side in ("left", "right"):
+            try:
+                state = await bed.get_core_climate(side)
+                print(
+                    f"{side}: mode={state.mode} remaining={state.remaining_minutes}"
+                )
+            except Exception as err:  # pragma: no cover - manual script
+                print(f"{side}: error: {err}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="asyncsleepiq",
     packages=["asyncsleepiq", "asyncsleepiq.fuzion"],
     package_data={"asyncsleepiq": ["py.typed"]},
-    version="{{VERSION_PLACEHOLDER}}",
+    version="0.3.0",
     description="ASync SleepIQ API",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/tests/test_climatecool.py
+++ b/tests/test_climatecool.py
@@ -1,0 +1,71 @@
+import asyncio
+import pytest
+
+from asyncsleepiq.bed import SleepIQBed
+
+
+class DummyAPI:
+    def __init__(self, response: str = "") -> None:
+        self.response = response
+        self.calls: list[tuple[str, str, list[str] | None]] = []
+
+    async def bamkey(self, bed_id: str, key: str, args: list[str] | None = None) -> str:
+        self.calls.append((bed_id, key, args))
+        return self.response
+
+
+BED_DATA = {
+    "name": "Bed",
+    "bedId": "1",
+    "macAddress": "00",
+    "sleeperLeftId": "L",
+    "sleeperRightId": "R",
+    "components": [{"productclassification": "CLIMATECOOL", "base": "BASE", "model": "X"}],
+}
+
+
+def test_capability_detection() -> None:
+    bed = SleepIQBed(DummyAPI(), BED_DATA)
+    assert bed.capabilities.core_climate_cooling_only is True
+
+
+def test_set_cooling() -> None:
+    api = DummyAPI()
+    bed = SleepIQBed(api, BED_DATA)
+    asyncio.run(bed.foundation.init_core_climates())
+    asyncio.run(bed.set_core_climate("left", "cooling_pull_med", 240))
+    assert api.calls[-2] == ("1", "SetClimateMode", ["left", "cooling_pull_med", "240"])
+
+
+def test_stop_cooling() -> None:
+    api = DummyAPI()
+    bed = SleepIQBed(api, BED_DATA)
+    asyncio.run(bed.foundation.init_core_climates())
+    asyncio.run(bed.set_core_climate("right", "off", 0))
+    assert api.calls[-2] == ("1", "SetClimateMode", ["right", "off", "0"])
+
+
+def test_clamp_minutes() -> None:
+    api = DummyAPI()
+    bed = SleepIQBed(api, BED_DATA)
+    asyncio.run(bed.foundation.init_core_climates())
+    asyncio.run(bed.set_core_climate("left", "cooling_pull_low", 9999))
+    assert api.calls[-2] == ("1", "SetClimateMode", ["left", "cooling_pull_low", "600"])
+
+
+def test_reject_heating() -> None:
+    api = DummyAPI()
+    bed = SleepIQBed(api, BED_DATA)
+    asyncio.run(bed.foundation.init_core_climates())
+    with pytest.raises(ValueError):
+        asyncio.run(bed.set_core_climate("left", "heating_push_low", 30))
+
+
+def test_get_state() -> None:
+    api = DummyAPI("cooling_pull_med 240")
+    bed = SleepIQBed(api, BED_DATA)
+    asyncio.run(bed.foundation.init_core_climates())
+    state = asyncio.run(bed.get_core_climate("left"))
+    assert state.mode == "cooling_pull_med"
+    assert state.remaining_minutes == 240
+    assert api.calls[-1] == ("1", "GetClimateMode", ["left"])


### PR DESCRIPTION
## Summary
- detect ClimateCool capability and expose cooling-only core climate controls
- document ClimateCool usage and bump version to 0.3.0
- fix README grammar

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e4b562334833083934e1d90f07827